### PR TITLE
Update "ava" to version ^0.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/marekventur/png-to-jpeg#readme",
   "devDependencies": {
-    "ava": "^0.14.0",
+    "ava": "^0.15.1",
     "babel-eslint": "^6.0.4",
     "eslint": "^2.9.0",
     "eslint-plugin-babel": "^3.2.0",


### PR DESCRIPTION
<pre>0.15.1 / 2016-05-26
===================

  * 0.15.1
  * Prevent suppression of defaults in ava-files ([#878](https://github.com/avajs/ava/issues/878))
    * fix(cli): Remove default files from CLI
    The default files should be in one place (`ava-files.js`).
    Right now the defaults provided in `ava-files.js` aren't being used
    because the CLI pre-populates them.
    Closes [#875](https://github.com/avajs/ava/issues/875)
    * Fixup [#876](https://github.com/avajs/ava/issues/876)
  * minor tweaks

0.15.0 / 2016-05-25
===================

  * 0.15.0
  * add test.failing and add cb to test.serial ([#866](https://github.com/avajs/ava/issues/866))
    [skip ci]
  * Move images to media folder.
    It's a good time to do it since we are cutting a release, so npm will get the updated URL's shortly.
    [skip ci]
  * bump update-notifier. ([#869](https://github.com/avajs/ava/issues/869))
    * bump dependencies.
    arr-diff@3.0.0 causes failures, so skipping for now.
    * undo strip-bom => strip-bom-buf
    strip-bom-buf uses syntax unsupported in Node 0.10.
  * Fix AppVeyor Badge (leave it pointing to Sindre's account).
  * document always hook with fail fast flag ([#858](https://github.com/avajs/ava/issues/858))
  * fix warning message
  * Drop unused `silent` option from `lib/fork.js`. ([#864](https://github.com/avajs/ava/issues/864))
    It's not used anywhere. I think we've refactored out all the tests that used to use it.
  * revert npm link fix. ([#859](https://github.com/avajs/ava/issues/859))
    This mostly reverts [#815](https://github.com/avajs/ava/issues/815), and [#827](https://github.com/avajs/ava/issues/827). The Node regressions they fixed were resolved in Node 6.2.0. The new behavior is just to print a warning message so people know how to fix it.
  * Fix "Test files must be run with the AVA CLI" warning. ([#862](https://github.com/avajs/ava/issues/862))
    We used to have a nice warning, telling people to use the CLI if they ran `node path/to/testfile.js`. It was broken by requiring `test-worker` to early. `test-worker` tries `JSON.parse(process.argv[2])`, which will likely throw. Preventing the helpful message.
    This adds a fix, and a regression test.
  * Pass shared caches to `globby`. ([#860](https://github.com/avajs/ava/issues/860))
    From the [`node-glob` docs](https://github.com/isaacs/node-glob#options):
    > At the very least, you may pass in shared symlinks, statCache, realpathCache, and cache options, so that parallel glob operations will be sped up by sharing information about the filesystem.
  * Avoid running the same file multiple times ([#856](https://github.com/avajs/ava/issues/856))
    * avoid running the same file multiple times
    * refactor `alreadySearchingParent` to make it a little easier to understand
  * add output for failing tests ([#837](https://github.com/avajs/ava/issues/837))
  * added missing todo definition for typescript ([#846](https://github.com/avajs/ava/issues/846))
  * RunStatus#prefixTitle should remove this.base only if it occurs at the beginning of the path ([#844](https://github.com/avajs/ava/issues/844))
    * RunStatus#prefixTitle(), replace this.base only if it occurs at the beggining of path
    * RunStatus#prefixTitle, filter out __tests__ from path
    * added tests for RunStatus#prefixTitle
  * doc: add korean translations link ([#855](https://github.com/avajs/ava/issues/855))
  * Add test.failing to the API section ([#853](https://github.com/avajs/ava/issues/853))
  * Update links to link to `avajs` ([#852](https://github.com/avajs/ava/issues/852))
  * Remove timestamp from non-watch test runs ([#838](https://github.com/avajs/ava/issues/838))
    * Remove timestamp from non-watch test runs
    * Fix mini reporter tests
    * Pass options object to reporter constructor with watching boolean
    * Refactor reporter options
    * Move timestamp lines to watcher test
  * Improve the issue template.
    The current issue template uses HTML comment tags to remove template text from the rendered output. I have gone through the last dozen issues filed, and it appears everyone deletes that anyways. By removing the comment tags, people can click "Preview" and get a pretty print of the template markdown.
    Reformat lists and links. Tries to get links as close to the left edge as possible, so they are easy to see, and copy-paste from the raw markdown editor. Puts multiple links on their own line for the same reason.
    Adds a request that they explicitly tell us what their AVA and `npm` versions are.
    Adds a section for their AVA config and CLI args.
    Adds a section for linking to thier project if public.
    Requests they create a minimal reproduction and post it to GitHub.
    Closes [#787](https://github.com/avajs/ava/issues/787)
  * refactor watcher ([#766](https://github.com/avajs/ava/issues/766))
    * refactor watcher tests
    * move some methods from watcher to AvaFiles
    * add some tests for ava-files
    * add more test coverage
    * fix linter error after merge
    * PR Feedback
    * use cross-platform split
  * update coveralls badge
  * api#run should return runStatus even when no files are found ([#839](https://github.com/avajs/ava/issues/839))
  * readme - linkify the logo
  * too much work setting up an org account for appveyor, blah
    just going to use mine as it works
  * remove mention-bot
    It turned out to be more annoying than useful...
  * move the project into an organization ✨
  * Add macro support. ([#832](https://github.com/avajs/ava/issues/832))
    * Basic macro support.
    This adds basic macro support as discussed in [#695](https://github.com/avajs/ava/issues/695).
    It does not completely implement the spec outlined there, specifically:
    - The macro can only specify the title using a function in `macroFn.title`. We discussed allowing `macroFn.title` to also be a string, and allowing some form of template language for extracting a title. However, using ES2015 string templates is already pretty easy, so we may just skip this.
    - We discussed allowing groups of tests to be created using arrays.
    Both the above proposals are found in [this comment](https://github.com/sindresorhus/ava/issues/695#issuecomment-205929738). They both enhance the implementation found in this commit, and would not break the contract. So I don't think there is anything preventing us from shipping this now.
    * fix readme indentation
    * spread arguments
    * Allow arrays of macros
    * pass providedTitle as first argument to title function.
    * improve docs
  * Protect against bad argument passed to t.throws. ([#834](https://github.com/avajs/ava/issues/834))
    If a non-function, non-promise, non-observable argument (i.e. a string)  is passed to `t.throws`, the assertion passes. This obviously isn't what we want.
  * Follow-up to [#831](https://github.com/avajs/ava/issues/831) ([#835](https://github.com/avajs/ava/issues/835))
    * change failing test hint
    * mark .failing as code in readme
    * group and reword failing tests
    The tests are better when grouped together. I tried to give them more consistent titles too.
    * remove spurious trailing space in t.end error message
  * A way to submit tests that should fail. ([#831](https://github.com/avajs/ava/issues/831))
    Fixes [#673](https://github.com/avajs/ava/issues/673).
  * fix crash in 'fake' browser env ([#829](https://github.com/avajs/ava/issues/829))
    * added failing test for source mapped exceptions in what looks like a browser env
    * added environment: node setting to sourceMapSupport.install()
  * Remove 'ready' event from API ([#828](https://github.com/avajs/ava/issues/828))
  * Only fix `npm link` of AVA as necessary. ([#827](https://github.com/avajs/ava/issues/827))
  * Limited Process Pools ([#791](https://github.com/avajs/ava/issues/791))
    New experimental `--concurrency` option. Note that `.only` behavior won't work reliably across test files when concurrency is limited.
  * Fix typo in `browser-testing` recipe ([#821](https://github.com/avajs/ava/issues/821))
  * add `after.always` and `afterEach.always` hooks ([#806](https://github.com/avajs/ava/issues/806))
    Fixes [#474](https://github.com/avajs/ava/issues/474)
    * add after.always, afterEach.always hook
    * update readme about always modifier
    * add test for verifying throw
    * add tests for verifying always hook are added
    * update readme for better "always" explaination
    * fix typo in test/test-collection.js
    * better always checking and implement
    * modify error message for only
    * fix build error
    * add always to default in test
  * Fix profiling script and add some tests for it. ([#812](https://github.com/avajs/ava/issues/812))
    * fix profiler script
    * add some profiling tests
    * fix some lint errors
    * disable eslint error for profile.js
    * fix for Node.js < 4
    eventEmitter.listenerCount was not a thing in days of yore.
    * Exit process async for Node 0.10 which emits uncaught exceptions async.
    * use process.execPath ... because windows
    * fix error-code descrepencies on Windows
  * Fix `npm link` usage on Node.js 6 ([#815](https://github.com/avajs/ava/issues/815))
  * Added std dev to benchmark stats ([#744](https://github.com/avajs/ava/issues/744))
  * update the fly-ava repository url ([#813](https://github.com/avajs/ava/issues/813))
  * add podcast episode to links ([#804](https://github.com/avajs/ava/issues/804))
  * update code of conduct
  * test Node.js 6 on AppVeyor
  * Strip ANSI escape codes in TAP test titles ([#792](https://github.com/avajs/ava/issues/792))
  * doc: Adding french translation link to the React recipe ([#796](https://github.com/avajs/ava/issues/796))
  * Remove unneeded eslint-disable comment ([#801](https://github.com/avajs/ava/issues/801))
  * use strict deep equality assertions in tests
    to better match the AVA t.deepEqual assertion
  * minor cleanup of [#747](https://github.com/avajs/ava/issues/747)
  * React recipe ([#747](https://github.com/avajs/ava/issues/747))
  * 🐐 removed XO by mistake in https://github.com/sindresorhus/ava/commit/ec05e53a1d50b54465f904493553ec0dc3c612ce
  * test on Node.js 6
  * Use `not-so-shallow` module to improve `t.deepEqual()` ([#777](https://github.com/avajs/ava/issues/777))
  * add spinner fallback for Windows
    The `dots` spinner doesn't work there.
  * remove duplicate babel-code-frame dependency ([#778](https://github.com/avajs/ava/issues/778))
  * Throwing synchronously inside a callback style test should fail it immediately. ([#774](https://github.com/avajs/ava/issues/774))
    Fixes [#748](https://github.com/avajs/ava/issues/748).
  * Merge pull request [#760](https://github.com/avajs/ava/issues/760) from sindresorhus/package-hash
    compute cache salt using package-hash
  * update t.plan recipe ([#769](https://github.com/avajs/ava/issues/769))
  * bump dependencies
  * Remove trailing comma to make JSON valid ([#768](https://github.com/avajs/ava/issues/768))
  * Removed stray characters from CLI sample output ([#767](https://github.com/avajs/ava/issues/767))
  * caching-precompiler: set default .babelConfig value
  * compute cache salt using package-hash
  * remove XO ignore in package.json
  * ✨ Delighted to welcome @sotojuan to the team! 🎉
  * minor maintaining.md tweaks
  * fix some XO lint issues
  * fix typo in readme ([#763](https://github.com/avajs/ava/issues/763))
    There was a trailing comma after the es2015 "presets" key.
  * Merge pull request [#758](https://github.com/avajs/ava/issues/758) from sindresorhus/remember-failures
  * Fix region dependent test failures. ([#761](https://github.com/avajs/ava/issues/761))
    The way lolex was being used in the reporters tests caused inconsistent output in different timezones, and therefore test failures.

1.0.0 / 2016-04-14
==================

  * watcher: remember failures from previous tests
    Fixes [#699](https://github.com/avajs/ava/issues/699). The watcher tracks how many failures (actual failures, but also
    rejections and uncaught exceptions) occurred for each test file. After each run,
    if there are failures from files that were not rerun, the count is added to the
    logger output.
  * api: use relative paths for RunStatus exceptions
    Sometimes the API sends exceptions to RunStatus. Ensure the file path for those
    exceptions is relative, just like the exceptions coming from the fork emitter.
    If the exception doesn't apply to any specific file, ensure the `file` is
    undefined. I haven't bothered adding tests for this though.
  * watcher: Don't clear reporter if previous run had errors ([#757](https://github.com/avajs/ava/issues/757))
    Don't clear the reporter if the previous run had exceptions or rejections.
    Improve the stubbing of the run status in the tests.
  * ensure watcher receives dependencies again ([#756](https://github.com/avajs/ava/issues/756))
    Since [#713](https://github.com/avajs/ava/issues/713) the API no longer emits 'dependencies' events. These are emitted
    instead by the RunStatus, which can be obtained by listening to the 'test-run'
    event on the API.
    The watcher tests use a mocked API object which wasn't updated to reflect these
    changes. Consequently dependency tracking was broken since [#713](https://github.com/avajs/ava/issues/713) was merged.
    This commit fixes the watcher and the corresponding tests. I've also added an
    integration test which does not rely on mocking, helping us detect breakage
    sooner.
  * change remaining TestData identifiers to RunStatus ([#755](https://github.com/avajs/ava/issues/755))
  * fix failing test
    Not caught earlier probably because [#730](https://github.com/avajs/ava/issues/730) wasn't rebased.
  * Improve watch logging ([#737](https://github.com/avajs/ava/issues/737))
    * display current time when mini & verbose reporters finish
    I'm using toLocaleTimeString() which works even back to Node.js 0.10. Forcing a
    24-hour clock because we're geeks.
    * watcher: restart logger on subsequent runs
    The CLI starts the logger so the watcher shouldn't reset it on its first run.
    Restart the logger after resetting, this allows the mini reporter to render its
    spinner.
    * better api.run stub in watcher test
    Return an object for the runStatus, add assertions to verify this object is
    passed to logger.finish()
    * assert that r/rs reruns all tests
    * clear mini reporter in watch mode
    Clear the mini reporter unless the previous run had failures, or "r\n" was
    entered on stdin.
    * consistent empty lines in finish output
    Always print two empty lines before each error/rejection/exception when the mini
    and verbose reporters finish. Remove trailing whitespace from stack traces.
    Always print an empty line after the finish output.
    Add a test helper to more easily compare line output, with useful debug
    information. At the moment this new helper is only used for failing tests.
    * print line if reporter was not be cleared
    Watch mode won't clear the mini reporter if there were errors, or "r\n" was
    entered on stdin. The verbose reporter can't be cleared at all. To improve the
    separation between multiple test runs, write a horizontal line when starting a
    new test run and the reporter was not cleared.
    * remove debug output from cli test
  * Improve source pattern handling ([#730](https://github.com/avajs/ava/issues/730))
    * watcher: correctly test if source is in the cwd
    Make sure the path starts with ../ (after platform-specific slashes have been
    corrected). Clarify existing test and add a case where the source starts with
    two dots but is still in the current working directory.
    * change handling of negated source patterns
    Fixes [#614](https://github.com/avajs/ava/issues/614). Allow negated source patterns to be specified without unsetting the
    default negation patterns.
    Allow source patterns to override the default negation patterns if they start
    with one of the ignored directories.
    * update watch mode docs
    * Suggest `watch:test` as the npm script
    * Document how to always enable watch mode using the ava section in package.json
    * Recommend source patterns are configured through the ava section in package.json
    * Suggest using the verbose reporter when debugging
  * Disable TAP reporter in watch mode ([#732](https://github.com/avajs/ava/issues/732))
    * disable tap reporter in watch mode
    Fixes [#672](https://github.com/avajs/ava/issues/672)
    * write missing chokidar error to stderr
  * detect improper use of t.throws ([#742](https://github.com/avajs/ava/issues/742))
    * detect improper use of t.throws
    Protects against a common misuse of t.throws (Like that seen in [#739](https://github.com/avajs/ava/issues/739)).
    This required the creation of a custom babel plugin.
    https://github.com/jamestalmage/babel-plugin-ava-throws-helper
    * relative file path and colors
    * protect against null/undefined in _setAssertError
    * use babel-code-frame to do syntax highlighting on the Error
    * require `babel-code-frame` inline. It has a sizable dependency graph
    * remove middle section of message. It is redundant given code-frame
    * further tests and add documentation.
    * update readme.md
  * doc: add Italian translations links ([#746](https://github.com/avajs/ava/issues/746))
  * rename `TestData` => `RunStatus`
    I missed this while refactoring the API refactor PR.
  * Improve babelrc recipe ([#743](https://github.com/avajs/ava/issues/743))
  * increase power-assert's maxDepth option to 3. ([#740](https://github.com/avajs/ava/issues/740))
    Fixes [#681](https://github.com/avajs/ava/issues/681)
  * Put failing TAP test title in the second line ([#734](https://github.com/avajs/ava/issues/734))
    Fixes [#679](https://github.com/avajs/ava/issues/679)
  * Support more test filename conventions ([#721](https://github.com/avajs/ava/issues/721))
    * update docs with more conventions
    * fix glob for __tests__
    * add more conventions for test files to include
    * update __tests__ glob per
    https://github.com/sindresorhus/ava/pull/721#discussion_r58885097
    * Update documentation for default globs
  * clean up stat collection in runner ([#728](https://github.com/avajs/ava/issues/728))
    Follow-up to [#654](https://github.com/avajs/ava/issues/654). No longer collecting stats for every test that completes.
    Explicitly return `null` when no exclusive tests could be run.
  * Document issue labels ([#729](https://github.com/avajs/ava/issues/729))
    * document issue labels
    * minor fixup
  * Add strict mode in `enhanced-assert.js` ([#741](https://github.com/avajs/ava/issues/741))
  * fix lint issues
  * add missing link to .only modifier in watch mode recipe
  * Refactor API
    * extract files processing from api
    * extract test-data class from API
    * fix breakage from rebase
    * pass testData to reporters in every method
    * rename testData to runStatus
    * runStatus.listenToTestRun => runStatus.observeFork
    * rename test-data.js to run-status.js
    * fix failing watcher test</pre>
