### PR TITLE
Update "jpeg-js" to version ^0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "pify": "^2.3.0",
-    "jpeg-js": "^0.1.2",
+    "jpeg-js": "^0.2.0",
     "png-js": "^0.1.1"
   },
   "files": [


### PR DESCRIPTION
<pre>0.2.0 / 2016-06-05
==================

  * 0.2.0
  * let’s test for popular node.js versions
  * Improve docs and document typed array argument
  * test for taking a typed array as input to decode
  * formatting
  * test for typed array encode function
  * Merge branch 'wmossman-browser_support-2'
    Add native browser support using typed arrays for decode.
  * Update decoder to return Uint8Array if desired
    I made this change so that this module can be used on the browser. Tested on Chrome.</pre>
