### PR TITLE
Update "ava" to version ^0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/marekventur/png-to-jpeg#readme",
   "devDependencies": {
-    "ava": "^0.15.1",
+    "ava": "^0.16.0",
     "babel-eslint": "^6.0.4",
     "eslint": "^3.0.0",
     "eslint-plugin-babel": "^3.2.0",


### PR DESCRIPTION
<pre>0.16.0 / 2016-08-06
===================

  * 0.16.0
  * bump dependencies and remove unused ones
  * Add type definitions to notRegex ([#979](https://github.com/avajs/ava/issues/979))
  * Update Juan Soto link
  * provide clear error message when users attempt nested/async calls to `test` ([#961](https://github.com/avajs/ava/issues/961))
    Fixes [#948](https://github.com/avajs/ava/issues/948).
    AVA does not support nested / async calls to `test`, but we were not providing a great error message when users attempted that.
    * added failing test for expected error
    * tests passed: waiting for review
    * added test
    * changed error message
    * fixed error in test
    * changed 'hasBegunRunning' to 'hasStarted'
  * minor code style tweaks
  * Auto generate TypeScript definition to allow chaining ([#884](https://github.com/avajs/ava/issues/884))
  * add Dependency CI badge
    Not very useful, but want to promote Dependency CI because it's awesome.
  * minor readme tweaks
  * add new reporters section in the readme ([#955](https://github.com/avajs/ava/issues/955))
  * Update JSPM+SystemJS recipe per @jamestalmage.
    See istanbuljs/nyc[#305](https://github.com/avajs/ava/issues/305) - specifically [this comment and the one after it](https://github.com/istanbuljs/nyc/issues/305#issuecomment-231517122).
    Essentially, @jamestalmage brought up that it would be good to explicitly mention in the recipe that you should not pre-build your project with JSPM/SystemJS to run your tests. The purpose of ava-jspm-loader is that you do not have to build before testing.
    Closes [#954](https://github.com/avajs/ava/issues/954)
  * Translate React recipe to Spanish (es_ES) ([#940](https://github.com/avajs/ava/issues/940))
  * fix lint issues
  * Docs: Add link to french translation of JSPM recipe ([#957](https://github.com/avajs/ava/issues/957))
  * fix import-order linting errors
  * JSPM and SystemJS recipe.
    <!--
    Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes [#321](https://github.com/avajs/ava/issues/321)`. New features and bug fixes should come with tests.
    -->
    A recipe for using AVA with JSPM, per discussion on [#131](https://github.com/avajs/ava/issues/131). It requires the import of an external library I wrote for the purpose of encapsulating the loader shim so it can be maintained and updated. Here's a link to that library: [ava-jspm-loader](https://github.com/skorlir/ava-jspm-loader).
    Closes [#941](https://github.com/avajs/ava/issues/941)
  * Fix link to issue 751 and add link to french translation ([#946](https://github.com/avajs/ava/issues/946))
  * Document common pitfalls ([#919](https://github.com/avajs/ava/issues/919))
  * Fix babel-config file name. ([#932](https://github.com/avajs/ava/issues/932))
  * minor tweaks
  * linter: disable max-lines rule for tests
  * Extract babel config generation into it's own submodule ([#924](https://github.com/avajs/ava/issues/924))
    * extract babel config generation into it's own submodule
    * no need for defaults
    * reassign validate call
    * pr feedback
  * extract ava-files to it's own module ([#925](https://github.com/avajs/ava/issues/925))
    * ava-files should honor a `cwd` option.
    * Properly resolve test files in non-watch mode.
    * update test/watcher.js to reflect new AvaFiles Api
    * extract ava-files to it's own thing
  * readme: add note about uncaught exceptions ([#918](https://github.com/avajs/ava/issues/918))
    fixes issue [#917](https://github.com/avajs/ava/issues/917)
  * Chokidar shouldn't be an optional dependency ([#916](https://github.com/avajs/ava/issues/916))
  * Fix babel config in react recipe ([#927](https://github.com/avajs/ava/issues/927))
  * clarify readme example on adding AVA to package.json
    fixes [#922](https://github.com/avajs/ava/issues/922)
  * bump dependencies
  * fix lint issues with latest XO
  * bump ava-throws-helper
  * swap arr-diff for lodash.difference ([#914](https://github.com/avajs/ava/issues/914))
  * move power assert error message formatting to child processes ([#911](https://github.com/avajs/ava/issues/911))
    Fixes [#703](https://github.com/avajs/ava/issues/703)
    * moved power assert assertion error formatting to child processes
    * fix test that asserted presence of powerAssertContext on AssertionError
  * fix typo in test/api.js ([#910](https://github.com/avajs/ava/issues/910))
  * Fix TypeScript recipe. ([#907](https://github.com/avajs/ava/issues/907))
    Following the old example didn't work for me. It appears the new recommended way to install `tsc` is just to install `typescript`.
  * Add link to Typescript recipe ([#906](https://github.com/avajs/ava/issues/906))
  * Add concurrency to package.json config in readme.
  * Merge branch '0.15'
  * Fix Italian recipe links ([#902](https://github.com/avajs/ava/issues/902))
  * update to new power-assert-runtime ([#903](https://github.com/avajs/ava/issues/903))
    * updated to power-assert-runtime
    * added tests for power assert not throwing on experimental syntax
    * bump empower-core to 0.6.1</pre>
