### PR TITLE
Update "babel-eslint" to version ^7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/marekventur/png-to-jpeg#readme",
   "devDependencies": {
     "ava": "^0.16.0",
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^7.0.0",
     "eslint": "^3.0.0",
     "eslint-plugin-babel": "^3.2.0",
     "is-jpg": "^1.0.0"


### PR DESCRIPTION
<pre>7.0.0 / 2016-09-27
==================

  * 7.0.0
  * updates
  * remove eslint 2 logic ([#361](https://github.com/babel/babel-eslint/issues/361))
    * remove old code
    * remove async/await logic before eslint supported it
    * not needed
  * Remove the lodash.assign dependency ([#393](https://github.com/babel/babel-eslint/issues/393))
    lodash.assign is deprecated:
    ```
    npm WARN deprecated lodash.assign@4.2.0: This package is deprecated.
    Use Object.assign.
    ```
  * chore(package): update babylon to version 6.11.2 ([#391](https://github.com/babel/babel-eslint/issues/391))
    https://greenkeeper.io/
  * chore(package): update espree to version 3.3.1 ([#394](https://github.com/babel/babel-eslint/issues/394))
    https://greenkeeper.io/
  * chore(package): update eslint to version 3.6.0 ([#392](https://github.com/babel/babel-eslint/issues/392))
    https://greenkeeper.io/
  * update test line number [skip ci]
  * eslint-plugin-flow-vars -> eslint-plugin-flowtype ([#374](https://github.com/babel/babel-eslint/issues/374)) [skip ci]
  * add deps for npm 2
  * typo
  * Merge pull request [#354](https://github.com/babel/babel-eslint/issues/354) from babel/eslint-config-babel
    Use eslint-config-babel
  * lint on ci
  * why..
  * use .js
  * Use eslint-config-babel
  * chore(package): update mocha to version 3.0.0 ([#356](https://github.com/babel/babel-eslint/issues/356))
    https://greenkeeper.io/
  * Drop node < 4 ([#358](https://github.com/babel/babel-eslint/issues/358))
  * Fix tests for eslint 3.2 ([#352](https://github.com/babel/babel-eslint/issues/352))
  * Add note about eslint 3 [skip ci]
  * Test eslint 3 and 2 on travis ([#340](https://github.com/babel/babel-eslint/issues/340))
    closes [#332](https://github.com/babel/babel-eslint/issues/332)
  * Fix tests for eslint 3.0
    Seems that eslint got a lot smarter and reports vars that are used, but are useless as unused
    These examples are also failing with espree</pre>
